### PR TITLE
aws_vpc_dhcp_option_association's import id need vpc_id

### DIFF
--- a/internal/rules/providers/aws/aws_vpc_dhcp_options_association.go
+++ b/internal/rules/providers/aws/aws_vpc_dhcp_options_association.go
@@ -1,0 +1,17 @@
+package aws
+
+import (
+	"github.com/gainings/tfirmg/internal/model/resourceid"
+	"github.com/gainings/tfirmg/internal/rules"
+)
+
+func init() {
+	rules.Register("aws_vpc_dhcp_options_association", AWSDhcpOptionsAssociationRule{})
+}
+
+type AWSDhcpOptionsAssociationRule struct{}
+
+func (r AWSDhcpOptionsAssociationRule) Generate(attributes map[string]interface{}) *resourceid.ResourceID {
+	id := resourceid.ResourceID(attributes["vpc_id"].(string))
+	return &id
+}


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association#import